### PR TITLE
Removing obsolete OpenAI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Community discussion: https://discourse.joplinapp.org/t/28316
 - **Literature review:**
     - Run the command `Research with Jarvis`, write what you're interested in, and optionally adjust the search parameters. Wait 2-3 minutes for all the output to appear in the note (depending on internet traffic). Jarvis will update the content as it finds new information on the web (using Semantic Scholar, Crossref, Elsevier, Springer & Wikipedia databases). In the end you will get a report with the following sections: title, prompt, research questions, queries, references, review and follow-up questions. For more information see [this post](https://medium.com/@alondmnt/ai-powered-literature-review-6918ee180304).
 - **Autocomplete anything:**
-    - `Chat with Jarvis` will try to extend any content. Therefore, this essentially serves as a general-purpose autocomplete command. You can remove the speaker attribution ("User:") by cleaning the `response suffix` field in the settings. The `text-davinci-003` model is recommended for this use case.
+    - `Chat with Jarvis` will try to extend any content. Therefore, this essentially serves as a general-purpose autocomplete command. You can remove the speaker attribution ("User:") by cleaning the `response suffix` field in the settings. The `gpt-3.5-turbo-instruct` model is recommended for this use case.
 - **Text generation:**
     - Run the command `Ask Jarvis` and write your query in the pop-up window, or select a prompt text in the editor before running the command. You can also enhance your query with predefined (or customized) prompt templates from the dropdown lists.
 - **Text editing:**

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -89,7 +89,7 @@ async function edit_action(dialogHandle: string, input: string, settings: any): 
   ];
   let edit: string;
   let resultValue: string = input;
-
+  let resultLabel: string = 'Selected text';
   // add iteration variable so cycles can be monitored
   let iteration = 0;
   do {
@@ -99,11 +99,11 @@ async function edit_action(dialogHandle: string, input: string, settings: any): 
         <form name="ask">
           <h3>Edit with Jarvis</h3>
           <div id="resultTextbox">
-            <label for="result">Selected text</label><br>
+            <label for="result">${resultLabel}</label><br>
             <textarea id="taresult" name="result">${resultValue}</textarea>
           </div>
           <div id="promptTextbox">
-            <label for="prompt">prompt</label><br>
+            <label for="prompt">Prompt</label><br>
             <textarea id="taprompt" name="prompt" placeholder="How would you like Jarvis to edit?"></textarea>
           </div>
         </form>
@@ -116,24 +116,29 @@ async function edit_action(dialogHandle: string, input: string, settings: any): 
     result = await joplin.views.dialogs.open(dialogHandle);
 
     if (result.id === "submit" || result.id === "resubmit" || result.id === "clear") {
+      // replace the text in result box with original selection
       if (result.id === "clear") {
         resultValue = input;
+        resultLabel = 'Selected text';
       } else {
         resultValue = await query_edit(result.formData.ask.result, result.formData.ask.prompt, settings);
+        resultLabel = 'Edited text';
       };
+      // re-create dialogue
       await joplin.views.dialogs.setHtml(dialogHandle, `
         <form name="ask">
           <h3>Edit with Jarvis</h3>
           <div id="resultTextbox">
-            <label for="result">Result</label><br>
+            <label for="result">${resultLabel}</label><br>
             <textarea id="taresult" name="result">${resultValue}</textarea>
           </div>
           <div id="promptTextbox">
-            <label for="prompt">prompt</label><br>
+            <label for="prompt">Prompt</label><br>
             <textarea id="taprompt" name="prompt" placeholder="How would you like Jarvis to edit?">${result.formData.ask.prompt}</textarea>
             </div>
         </form>
       `);
+      // recreate button set for the dialogue
       buttons = [
         { id: "resubmit", title: "Re-Submit" },
         { id: "clear", title: "Clear" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ joplin.plugins.register({
     joplin.commands.register({
       name: 'jarvis.edit',
       label: 'Edit selection with Jarvis',
+      iconName: 'far fa-edit',
       execute: async () => {
         edit_with_jarvis(dialogAsk);
       }
@@ -221,10 +222,12 @@ joplin.plugins.register({
     );
 
     joplin.views.toolbarButtons.create('jarvis.toolbar.notes.find', 'jarvis.notes.find', ToolbarButtonLocation.EditorToolbar);
+    joplin.views.toolbarButtons.create('jarvis.toolbar.edit', 'jarvis.edit', ToolbarButtonLocation.EditorToolbar);
     joplin.views.toolbarButtons.create('jarvis.toolbar.chat', 'jarvis.chat', ToolbarButtonLocation.EditorToolbar);
     joplin.views.toolbarButtons.create('jarvis.toolbar.annotate', 'jarvis.annotate.button', ToolbarButtonLocation.EditorToolbar);
 
     joplin.views.menuItems.create('jarvis.context.notes.find', 'jarvis.notes.find', MenuItemLocation.EditorContextMenu);
+    joplin.views.menuItems.create('jarvis.context.edit', 'jarvis.edit', MenuItemLocation.EditorContextMenu);
 
     await joplin.workspace.onNoteSelectionChange(async () => {
         if (model_embed.model === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ joplin.plugins.register({
       label: 'Edit selection with Jarvis',
       iconName: 'far fa-edit',
       execute: async () => {
-        edit_with_jarvis(dialogAsk);
+        edit_with_jarvis(model_gen, dialogAsk);
       }
     });
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -20,7 +20,6 @@ export async function load_generation_model(settings: JarvisSettings): Promise<T
     model = new HuggingFaceGeneration(settings);
 
   } else if (settings.model.includes('gpt') ||
-             settings.model.includes('davinci') ||
              settings.model.includes('openai')) {
     model = new OpenAIGeneration(settings);
 

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -209,7 +209,8 @@ export async function query_edit(input: string, instruction: string, settings: J
     await joplin.views.dialogs.showMessageBox('Error:' + data.error.message);
     return '';
   }
-  return data.choices[0].text;
+  // Remove leading and trailing whitespace or newline characters
+  return data.choices[0].text.trim();
 }
 
 // returns the last messages up to a fraction of the total length

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -178,14 +178,23 @@ export async function query_embedding(input: string, model: string, api_key: str
 }
 
 export async function query_edit(input: string, instruction: string, settings: JarvisSettings): Promise<string> {
+  const promptEdit = `Rewrite the given the INPUT_TEXT in markdown, edit it according to the PROMPT provided, maintaining its original language. Ensure the output matches the language identified in the input text.  
+  [Prioritize clarity and accurate portrayal of the original information and context in the new style. The output should retain explicit markdown decorations (e.g., [link text](url), **bold**, _italic_) exactly as they appear in the INPUT_TEXT]
+
+  INPUT_TEXT: 
+  ${input}
+  
+  PROMPT: ${instruction}`;
   const responseParams = {
-    input: input,
-    instruction: instruction,
-    model: 'text-davinci-edit-001',
+    model: 'gpt-3.5-turbo-instruct',
+    prompt: promptEdit,
+    max_tokens: 4096 - promptEdit.length,
+    frequency_penalty: 0,
+    presence_penalty: 0,
     temperature: settings.temperature,
     top_p: settings.top_p,
   }
-  const response = await fetch('https://api.openai.com/v1/edits', {
+  const response = await fetch('https://api.openai.com/v1/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -178,10 +178,11 @@ export async function query_embedding(input: string, model: string, api_key: str
 }
 
 export async function query_edit(input: string, instruction: string, settings: JarvisSettings): Promise<string> {
-  const promptEdit = `Rewrite the given the INPUT_TEXT in markdown, edit it according to the PROMPT provided, maintaining its original language. Ensure the output matches the language identified in the input text.  
-  [Prioritize clarity and accurate portrayal of the original information and context in the new style. The output should retain explicit markdown decorations (e.g., [link text](url), **bold**, _italic_) exactly as they appear in the INPUT_TEXT]
-
-  INPUT_TEXT: 
+  const promptEdit = `Rewrite the given the INPUT_TEXT in markdown, edit it according to the PROMPT provided, maintaining its original language. Output in markdown format. Do not use links. Do not include literal content from the given prompt.
+  Use this format, replacing text in brackets with the result. Do not include the brackets in the output: 
+  [Output based on the prompt, in markdown format.]
+  
+  INPUT_TEXT:
   ${input}
   
   PROMPT: ${instruction}`;

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -178,14 +178,15 @@ export async function query_embedding(input: string, model: string, api_key: str
 }
 
 export async function query_edit(input: string, instruction: string, settings: JarvisSettings): Promise<string> {
-  const promptEdit = `Rewrite the given the INPUT_TEXT in markdown, edit it according to the PROMPT provided, maintaining its original language. Output in markdown format. Do not use links. Do not include literal content from the given prompt.
-  Use this format, replacing text in brackets with the result. Do not include the brackets in the output: 
-  [Output based on the prompt, in markdown format.]
-  
-  INPUT_TEXT:
-  ${input}
-  
-  PROMPT: ${instruction}`;
+  const promptEdit = `Rewrite the given the INPUT_TEXT in markdown, edit it according to the PROMPT provided, maintaining its original language. Given the following markdown text (INPUT_TEXT), please process the content by disregarding any markdown formatting symbols related to text decoration such as bold, italic, ~~strikethrough~~, and any hyperlinks. However, ensure to respect the structure including paragraphs, bullet points, and numbered lists. Any metadata or markdown symbols utilized for structural purposes like headers, lists, or blockquotes should be preserved. Do not interpret or follow any links in the text; treat them as plain text instead. After processing, return your response adhering to markdown format to maintain the original structure without the decorative markdown formatting.
+
+INPUT_TEXT: 
+${input}
+
+PROMPT: ${instruction}
+
+Ensure your output maintains meaningful content organization and coherence in markdown format, excluding the decorative markdown syntax and links.
+`;
   const responseParams = {
     model: 'gpt-3.5-turbo-instruct',
     prompt: promptEdit,

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -177,44 +177,6 @@ export async function query_embedding(input: string, model: string, api_key: str
   return vec;
 }
 
-export async function query_edit(input: string, instruction: string, settings: JarvisSettings): Promise<string> {
-  const promptEdit = `Rewrite the given the INPUT_TEXT in markdown, edit it according to the PROMPT provided, maintaining its original language. Given the following markdown text (INPUT_TEXT), please process the content by disregarding any markdown formatting symbols related to text decoration such as bold, italic, ~~strikethrough~~, and any hyperlinks. However, ensure to respect the structure including paragraphs, bullet points, and numbered lists. Any metadata or markdown symbols utilized for structural purposes like headers, lists, or blockquotes should be preserved. Do not interpret or follow any links in the text; treat them as plain text instead. After processing, return your response adhering to markdown format to maintain the original structure without the decorative markdown formatting.
-
-INPUT_TEXT: 
-${input}
-
-PROMPT: ${instruction}
-
-Ensure your output maintains meaningful content organization and coherence in markdown format, excluding the decorative markdown syntax and links.
-`;
-  const responseParams = {
-    model: 'gpt-3.5-turbo-instruct',
-    prompt: promptEdit,
-    max_tokens: 4096 - promptEdit.length,
-    frequency_penalty: 0,
-    presence_penalty: 0,
-    temperature: settings.temperature,
-    top_p: settings.top_p,
-  }
-  const response = await fetch('https://api.openai.com/v1/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + settings.openai_api_key,
-    },
-    body: JSON.stringify(responseParams),
-  });
-  const data = await response.json();
-
-  // handle errors
-  if (data.choices === undefined) {
-    await joplin.views.dialogs.showMessageBox('Error:' + data.error.message);
-    return '';
-  }
-  // Remove leading and trailing whitespace or newline characters
-  return data.choices[0].text.trim();
-}
-
 // returns the last messages up to a fraction of the total length
 function select_messages(
     messages: Array<{ role: string; content: string; }>, fraction: number) {

--- a/src/ux/settings.ts
+++ b/src/ux/settings.ts
@@ -84,7 +84,7 @@ export const model_max_tokens: { [model: string] : number; } = {
   'gpt-4': 8192,
   'gpt-3.5-turbo-16k': 16384,
   'gpt-3.5-turbo': 4096,
-  'text-davinci-003': 4096,
+  'gpt-3.5-turbo-instruct': 4096,
   'bison-001': 8196,
 };
 
@@ -282,7 +282,7 @@ export async function register_settings() {
         'gpt-4': '(online) OpenAI: gpt-4',
         'gpt-3.5-turbo-16k': '(online) OpenAI: gpt-3.5-turbo-16k',
         'gpt-3.5-turbo': '(online) OpenAI: gpt-3.5-turbo',
-        'text-davinci-003': '(online) OpenAI: text-davinci-003',
+        'gpt-3.5-turbo-instruct': '(online) OpenAI: gpt-3.5-turbo-instruct (successor of text-davinci-003 )',
         'openai-custom': '(online) OpenAI or compatible: custom model',
         'bison-001': '(online) Google PaLM',
         'Hugging Face': '(online) Hugging Face',

--- a/src/ux/view.css
+++ b/src/ux/view.css
@@ -1,7 +1,9 @@
 * {
   color: var(--joplin-color);
   background-color: var(--joplin-background-color);
+  margin: 0px;
 }
+/* container with rounded corners */
 #joplin-plugin-content {
   width: 560px;
   height: 420px;
@@ -11,15 +13,46 @@ form {
   height: 400px;
 }
 form > div {
-  margin: 0.5em 0;
+  margin: 1.5em 0;
 }
 form > div > label {
   display: block;
-  margin-bottom: 0.5em;
+  margin-bottom: -15px;
+  padding-left: 4px;
 }
 form > div > textarea {
   width: 98%;
   height: 290px;
+}
+#taresult {
+  padding: 5.200000000000003pt;
+  width: -webkit-fill-available;
+  height: -webkit-fill-available;
+  border-radius: 5px;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: medium;
+  line-height: 21px;
+  background-color: rgb(216, 216, 216);
+  color: rgb(63, 63, 63);
+  border-width: 0;
+}
+#taprompt {
+  padding: 5.200000000000003pt;
+  width: -webkit-fill-available;
+  height: -webkit-fill-available;
+  border-radius: 5px;
+  font-family: Arial, Helvetica, sans-serif;
+  background-color: rgb(238, 238, 238);
+  border-width: 0;
+}
+#resultTextbox {
+  width: 100%;
+  height: 250px;
+}
+#promptTextbox {
+  width: 100%;
+  height: 100px;
+  border-radius: 15px;
 }
 #research_prompt {
   height: 220px;

--- a/src/ux/view.css
+++ b/src/ux/view.css
@@ -15,7 +15,13 @@ form {
 form > div {
   margin: 1.5em 0;
 }
+
+}
 form > div > label {
+  display: block;
+  margin-bottom: 0.5em;
+}
+#resultTextbox label, #promptTextbox label {
   display: block;
   margin-bottom: -15px;
   padding-left: 4px;

--- a/src/ux/view.css
+++ b/src/ux/view.css
@@ -2,6 +2,8 @@
   color: var(--joplin-color);
   background-color: var(--joplin-background-color);
   margin: 0px;
+  border-radius: 3px;
+  font-family: Avenir, Arial, sans-serif;
 }
 /* container with rounded corners */
 #joplin-plugin-content {
@@ -13,13 +15,11 @@ form {
   height: 400px;
 }
 form > div {
-  margin: 1.5em 0;
-}
-
+  margin: 2px 0;
 }
 form > div > label {
   display: block;
-  margin-bottom: 0.5em;
+  margin-bottom: 2px;
 }
 #resultTextbox label, #promptTextbox label {
   display: block;
@@ -31,37 +31,29 @@ form > div > textarea {
   height: 290px;
 }
 #taresult {
-  padding: 5.200000000000003pt;
+  padding: 2px;
   width: -webkit-fill-available;
   height: -webkit-fill-available;
-  border-radius: 5px;
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: medium;
-  line-height: 21px;
-  background-color: rgb(216, 216, 216);
-  color: rgb(63, 63, 63);
-  border-width: 0;
+  margin-bottom: 20px;
 }
 #taprompt {
-  padding: 5.200000000000003pt;
+  padding: 2px;
   width: -webkit-fill-available;
   height: -webkit-fill-available;
-  border-radius: 5px;
-  font-family: Arial, Helvetica, sans-serif;
-  background-color: rgb(238, 238, 238);
-  border-width: 0;
 }
 #resultTextbox {
-  width: 100%;
+  width: 98%;
   height: 250px;
 }
 #promptTextbox {
-  width: 100%;
+  width: 98%;
   height: 100px;
-  border-radius: 15px;
 }
 #research_prompt {
-  height: 220px;
+  height: 240px;
+}
+#instruction, #scope, #role, #reasoning {
+  margin: 5px 0;
 }
 #instruction {
   width: 30%;


### PR DESCRIPTION
## Reason for changes
Following models are deprecated:
- `text-davinci-001`  - Successor model `gpt-3.5-turbo-instruct` was implemented.
- `text-davinci-003`  - Successor model `gpt-3.5-turbo-instruct` was implemented.

## Refactory of Edit with Jarvis:
	- Enhanced UX: 
		- added Re-submit button - for re-submitting request to Jarvis
		- added button for Clear - clearing changes in previewing text frame
		- added button for Replace - action for replacing original selected text
	- Updated CSS for improved UX with rounded corners and spacing