### PR TITLE
feat: add Note mode to chat panel

### DIFF
--- a/src/chatPanel.ts
+++ b/src/chatPanel.ts
@@ -2,7 +2,7 @@ import joplin from 'api';
 import MarkdownIt from 'markdown-it';
 import type { TextEmbeddingModel, TextGenerationModel } from './models/models';
 import type { JarvisSettings } from './ux/settings';
-import { chat_with_notes_panel, format_as_note_chat, type PanelChatMessage } from './commands/chat';
+import { chat_with_note_panel, chat_with_notes_panel, format_as_note_chat, type PanelChatMessage } from './commands/chat';
 import { clearObjectReferences } from './utils';
 
 const md = new MarkdownIt({ linkify: true, breaks: true });
@@ -71,15 +71,17 @@ function local_timestamp(date: Date): string {
     `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
 }
 
+type ChatMode = 'chat' | 'note' | 'collection';
+
 const panelCache: {
   history: CachedMessage[];
-  useNotes: boolean;
+  chatMode: ChatMode;
   draft: string;
   noteId: string;
   createdAt: string;
 } = {
   history: [],
-  useNotes: true,
+  chatMode: 'collection',
   draft: '',
   noteId: '',
   createdAt: '',
@@ -93,7 +95,7 @@ export async function initialize_chat_panel(get_context: () => ChatPanelContext)
   <div class="jarvis-chat-panel">
 <div id="chat-log" class="jarvis-chat-log" aria-live="polite"></div>
     <div class="jarvis-chat-input-wrap">
-      <span id="chat-mode" class="jarvis-chat-mode" title="Toggle Notes/Chat mode (Shift+Tab)">Notes</span>
+      <span id="chat-mode" class="jarvis-chat-mode" title="Switch mode (Shift+Tab)">Collection</span>
       <textarea id="chat-input" class="jarvis-chat-input" placeholder="Ask Jarvis about your notes..." rows="2"></textarea>
     </div>
     <div class="jarvis-chat-actions">
@@ -113,7 +115,7 @@ export async function initialize_chat_panel(get_context: () => ChatPanelContext)
       return {
         type: 'restore',
         history: panelCache.history,
-        useNotes: panelCache.useNotes,
+        chatMode: panelCache.chatMode,
         draft: panelCache.draft || '',
         platform: get_context().settings.notes_device_platform || 'desktop',
       };
@@ -128,7 +130,9 @@ export async function initialize_chat_panel(get_context: () => ChatPanelContext)
     }
 
     if (message.type === 'modeChange') {
-      panelCache.useNotes = !!message.useNotes;
+      if (message.chatMode === 'chat' || message.chatMode === 'note' || message.chatMode === 'collection') {
+        panelCache.chatMode = message.chatMode;
+      }
       return { type: 'ack' };
     }
 
@@ -205,6 +209,34 @@ export async function initialize_chat_panel(get_context: () => ChatPanelContext)
       } catch (error) {
         const msg = error instanceof Error ? error.message : 'Unknown error';
         return { type: 'response', error: true, text: `Chat failed: ${msg}` };
+      }
+    }
+
+    if (message.type === 'chatWithNote') {
+      const prompt = typeof message.prompt === 'string' ? message.prompt.trim() : '';
+      if (!prompt) {
+        return { type: 'response', text: 'Please enter a prompt.' };
+      }
+
+      const runtime = get_context();
+      if (runtime.model_gen?.model === null && typeof runtime.model_gen?.initialize === 'function') {
+        await runtime.model_gen.initialize();
+      }
+      if (!runtime.model_gen?.model) {
+        return { type: 'response', error: true, text: 'Jarvis model is not initialised yet. Please try again in a moment.' };
+      }
+
+      try {
+        const history = sanitize_history(message.history);
+        panelCache.history = cache_history(history);
+        if (!panelCache.createdAt) panelCache.createdAt = local_timestamp(new Date());
+        const text = await chat_with_note_panel(history, runtime.model_gen, runtime.settings);
+        const html = md.render(text);
+        panelCache.history.push({ role: 'assistant', content: text, html });
+        return { type: 'response', text, html };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+        return { type: 'response', error: true, text: msg };
       }
     }
 

--- a/src/chatPanelWebview.js
+++ b/src/chatPanelWebview.js
@@ -1,8 +1,18 @@
 (() => {
+  const MODES = {
+    chat:       { label: 'Chat',       placeholder: 'Chat with Jarvis...',          messageType: 'chat' },
+    note:       { label: 'Note',       placeholder: 'Ask about the current note...', messageType: 'chatWithNote' },
+    collection: { label: 'Collection', placeholder: 'Ask Jarvis about your notes...', messageType: 'chatWithNotes' },
+  };
+  // Rotation order: collection (default) → note → chat → collection. Click and
+  // Shift+Tab both advance through this cycle.
+  const MODE_ORDER = ['collection', 'note', 'chat'];
+  const nextMode = (mode) => MODE_ORDER[(MODE_ORDER.indexOf(mode) + 1) % MODE_ORDER.length];
+
   const history = [];
   let initialized = false;
   let requestInFlight = false;
-  let useNotes = true;
+  let chatMode = 'collection';
   let chatLog = null;
   let chatInput = null;
   let sendButton = null;
@@ -10,6 +20,13 @@
   let newButton = null;
   let modeButton = null;
   let draftTimer = null;
+
+  function applyMode(mode) {
+    resolveElements();
+    const cfg = MODES[mode] || MODES.collection;
+    if (modeButton) modeButton.textContent = cfg.label;
+    if (chatInput) chatInput.placeholder = cfg.placeholder;
+  }
 
   function resolveElements() {
     if (!chatLog) {
@@ -146,10 +163,9 @@
     }
 
     // restore mode
-    if (typeof message.useNotes === 'boolean') {
-      useNotes = message.useNotes;
-      if (modeButton) modeButton.textContent = useNotes ? 'Notes' : 'Chat';
-      if (chatInput) chatInput.placeholder = useNotes ? 'Ask Jarvis about your notes...' : 'Chat with Jarvis...';
+    if (typeof message.chatMode === 'string' && MODES[message.chatMode]) {
+      chatMode = message.chatMode;
+      applyMode(chatMode);
     }
 
     // restore draft
@@ -226,7 +242,7 @@
 
     try {
       const response = await withTimeout(webviewApi.postMessage({
-        type: useNotes ? 'chatWithNotes' : 'chat',
+        type: (MODES[chatMode] || MODES.collection).messageType,
         prompt,
         history,
       }), 120000);
@@ -289,13 +305,9 @@
         return;
       }
       if (target.id === 'chat-mode') {
-        useNotes = !useNotes;
-        target.textContent = useNotes ? 'Notes' : 'Chat';
-        resolveElements();
-        if (chatInput) {
-          chatInput.placeholder = useNotes ? 'Ask Jarvis about your notes...' : 'Chat with Jarvis...';
-        }
-        webviewApi.postMessage({ type: 'modeChange', useNotes });
+        chatMode = nextMode(chatMode);
+        applyMode(chatMode);
+        webviewApi.postMessage({ type: 'modeChange', chatMode });
       }
     });
 
@@ -333,11 +345,9 @@
       }
       if (event.key === 'Tab' && event.shiftKey) {
         event.preventDefault();
-        useNotes = !useNotes;
-        resolveElements();
-        if (modeButton) modeButton.textContent = useNotes ? 'Notes' : 'Chat';
-        if (chatInput) chatInput.placeholder = useNotes ? 'Ask Jarvis about your notes...' : 'Chat with Jarvis...';
-        webviewApi.postMessage({ type: 'modeChange', useNotes });
+        chatMode = nextMode(chatMode);
+        applyMode(chatMode);
+        webviewApi.postMessage({ type: 'modeChange', chatMode });
       }
     });
 

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -78,6 +78,38 @@ export async function chat_with_notes_panel(
   return `${completion}\n\n${result.note_links}`.trim();
 }
 
+/** Panel chat scoped to the currently open note. The note body is prepended to
+ *  the panel history and parsed as a prior conversation turn (via _parse_chat's
+ *  first_role heuristic), mirroring `chat_with_jarvis` invoked at the end of a
+ *  note. Each reply is tagged with a clickable link to the source note. */
+export async function chat_with_note_panel(
+  history: PanelChatMessage[],
+  model_gen: TextGenerationModel,
+  settings: JarvisSettings,
+): Promise<string> {
+  const note = await joplin.workspace.selectedNote();
+  if (!note) {
+    throw new Error('Open a note to chat about it, or switch mode with Shift+Tab.');
+  }
+  try {
+    const title = note.title || 'Untitled';
+    const note_body = stripJarvisBlocks(note.body ?? '');
+    const chat_block = format_as_note_chat(history, settings);
+    const composed = `${note_body}\n${chat_block}`;
+    const truncated = split_by_tokens(
+      [composed], model_gen, model_gen.memory_tokens, 'last',
+    )[0].join(' ');
+    const raw = (await model_gen.chat(truncated)) || '';
+    const completion = raw
+      .replace(model_gen.model_prefix, '')
+      .replace(model_gen.user_prefix, '')
+      .trim();
+    return `${completion}\n\n[${title}](:/${note.id})`;
+  } finally {
+    clearObjectReferences(note);
+  }
+}
+
 type NotesChatPipelineResult = {
   completion: string;
   note_links: string;


### PR DESCRIPTION
## Summary

- Adds a third chat panel mode, **Note**, that scopes the chat to the currently open note — equivalent to invoking `chat_with_jarvis` at the end of the note, but driven from the panel and threaded with the panel's chat history.
- Replaces the binary `Notes`/`Chat` toggle with a 3-state rotation (click or Shift+Tab) cycling **Collection -> Note -> Chat -> Collection**. Collection remains the default; existing `useNotes:true` users land on Collection unchanged.
- `chat_with_note_panel` reuses the same primitives as `chat_with_jarvis` (`stripJarvisBlocks`, `split_by_tokens('last')`, `format_as_note_chat`, `model_gen.chat`). `_parse_chat`'s `first_role` heuristic attributes the note body as a prior assistant turn, so embedded chat blocks continue to work.
- Each Note-mode reply is tagged with a clickable `[Title](:/id)` link to the source note; per-turn note tracking falls out naturally because each send re-reads `joplin.workspace.selectedNote`.
- If no note is open in Note mode, the send is blocked with an actionable error ("Open a note to chat about it, or switch mode with Shift+Tab.") via the panel's existing error-response path.

## Test plan

- [x] Mode rotation: click the indicator and confirm it cycles `Collection -> Note -> Chat -> Collection`.
- [x] Mode rotation via keyboard: focus the input, press Shift+Tab, confirm same cycle.
- [x] Default mode on first open is `Collection`; placeholder reads "Ask Jarvis about your notes...".
- [x] In `Chat` mode, sending a prompt works without notes context (placeholder "Chat with Jarvis...").
- [x] In `Note` mode with a note open, the reply references the open note's content and ends with a `[Title](:/id)` link that opens the source note when clicked.
- [x] Switching notes between turns in Note mode: each subsequent reply targets the newly-open note and links to it.
- [ ] In Note mode with no note open, sending shows the error message and the failed user turn is rolled back.
- [x] In `Collection` mode, RAG behaviour is unchanged.
- [x] Save button: produces a saved chat note that includes the per-turn source links inline.
- [x] New Chat: clears history but preserves the current mode selection.