### PR TITLE
feat: add Joplin AI as a chat provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [v0.13.4](https://github.com/alondmnt/joplin-plugin-jarvis/releases/tag/v0.13.4)
+*Released on 2026-07-14*
+
+- added: **Joplin AI** as a chat provider — chats through the model configured in Joplin's own **Settings → AI** (Joplin Cloud AI, an OpenAI-compatible endpoint, or Anthropic), so no API key is needed in Jarvis. Select it as the second option in **Chat: Model**. Desktop-only, and requires Joplin 3.7+ with the AI beta enabled. See the [guide](https://github.com/alondmnt/joplin-plugin-jarvis/blob/master/GUIDE.md#chat-with-joplin-ai).
+
+**Full Changelog**: https://github.com/alondmnt/joplin-plugin-jarvis/compare/v0.13.3...v0.13.4
+
+---
+
 # [v0.13.3](https://github.com/alondmnt/joplin-plugin-jarvis/releases/tag/v0.13.3)
 *Released on 2026-06-04T15:13:21Z*
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,6 +1,7 @@
 # Jarvis Guide
 
 - [Setup a custom model](#setup-a-custom-model)
+- [Chat with Joplin AI](#chat-with-joplin-ai)
 - [Annotate note with Jarvis](#annotate-note-with-jarvis)
 - [Chat with your notes](#chat-with-your-notes)
 
@@ -168,6 +169,24 @@ Here is an example of how to set up Claude V2 via [OpenRouter](https://openroute
 | Chat: OpenAI (or compatible) custom model ID | Yes | anthropic/claude-2 |
 | Chat: Custom model is a conversation model | Yes | Yes |
 | Chat: Custom model API endpoint | Yes | https://openrouter.ai/api/v1/chat/completions |
+
+## Chat with Joplin AI
+
+Joplin 3.7 and newer (desktop) include a built-in AI feature (beta) with its own provider and model, configured in Joplin's own settings. Jarvis can chat through whichever model you've set up there, so you don't need to enter an API key in Jarvis.
+
+1. In Joplin, open **Settings → AI**, enable AI, and pick a provider and model (Joplin Cloud AI, an OpenAI-compatible endpoint, or Anthropic). For cloud providers, also allow remote access.
+2. Set up Jarvis as follows
+
+| Setting | Advanced | Value |
+|---------|----------|-------|
+| Chat: Model | No | Joplin AI (built-in, configured in Joplin → Settings → AI) |
+
+Notes:
+
+- This provider is desktop-only and requires Joplin 3.7 or newer (the AI beta). If it's unavailable, Jarvis pops up a message when the model loads.
+- The model, provider, and API key are all controlled in Joplin, not in Jarvis. Configuration errors (AI disabled, remote access not allowed, missing key) point you back to **Joplin → Settings → AI**.
+- The chat temperature is passed through (Jarvis's 0-20 scale is mapped to Joplin's 0-1); other Jarvis model parameters don't apply.
+- This affects the chat model only. Note embeddings (related notes, chat with your notes) still use the model set under **Notes: Semantic similarity model**.
 
 ## Annotate note with Jarvis
 

--- a/api/Joplin.d.ts
+++ b/api/Joplin.d.ts
@@ -10,6 +10,7 @@ import JoplinSettings from './JoplinSettings';
 import JoplinContentScripts from './JoplinContentScripts';
 import JoplinClipboard from './JoplinClipboard';
 import JoplinWindow from './JoplinWindow';
+import JoplinAi from './JoplinAi';
 import BasePlatformImplementation from '../BasePlatformImplementation';
 import JoplinImaging from './JoplinImaging';
 /**
@@ -37,6 +38,7 @@ export default class Joplin {
     private contentScripts_;
     private clipboard_;
     private window_;
+    private ai_;
     private implementation_;
     constructor(implementation: BasePlatformImplementation, plugin: Plugin, store: any);
     get data(): JoplinData;
@@ -57,6 +59,13 @@ export default class Joplin {
     get views(): JoplinViews;
     get interop(): JoplinInterop;
     get settings(): JoplinSettings;
+    /**
+     * Access to AI features: chat completions and semantic search over the
+     * local embeddings index. See {@link JoplinAi}.
+     *
+     * <span class="platform-desktop">desktop</span>
+     */
+    get ai(): JoplinAi;
     /**
      * It is not possible to bundle native packages with a plugin, because they
      * need to work cross-platforms. Instead access to certain useful native

--- a/api/JoplinAi.d.ts
+++ b/api/JoplinAi.d.ts
@@ -1,0 +1,82 @@
+import { ChatMessage, ChatOptions, ChatResult, SearchOptions, SearchResult } from './types';
+/**
+ * Provides access to AI models configured by the user. The active provider
+ * (Joplin Cloud AI, OpenAI-compatible, or Anthropic) and the model are picked
+ * by the user in the Joplin settings — plugins inherit whichever is active.
+ *
+ * AI is disabled by default. The user must enable it in the settings, and
+ * separately grant permission to use a remote (cloud-hosted) provider before
+ * any plugin call will succeed.
+ *
+ * If the user is signed into Joplin Cloud, AI works zero-config — they only
+ * need to flip the master toggle on.
+ *
+ * <span class="platform-desktop">desktop</span>
+ */
+export default class JoplinAi {
+    /**
+     * Sends a chat completion request to the active AI provider and returns
+     * the assistant's response as an object with a `text` property. The object
+     * shape is stable so future fields (e.g. token usage, finish reason) can be
+     * added without breaking existing plugins.
+     *
+     * The active provider and model are controlled by the user in Settings →
+     * AI. Plugins should not assume any particular provider or model.
+     *
+     * This call throws when:
+     *
+     * - AI features are disabled (`AI features are disabled`).
+     * - The active provider is remote and the user has not allowed remote
+     *   providers (`Remote AI access is not allowed`).
+     * - The provider is misconfigured, e.g. missing API key or model name
+     *   (`*provider* has no API key configured`).
+     * - The provider returns an HTTP error (the message includes the status
+     *   and any detail returned by the provider).
+     *
+     * Plugins should catch these errors and present a user-friendly message
+     * pointing the user at the Joplin settings.
+     *
+     * @example
+     * ```typescript
+     * const reply = await joplin.ai.chat([
+     *     { role: 'system', content: 'You are a concise assistant.' },
+     *     { role: 'user', content: 'Summarise this note: ...' },
+     * ]);
+     * console.log(reply.text);
+     * ```
+     */
+    chat(messages: ChatMessage[], options?: ChatOptions): Promise<ChatResult>;
+    /**
+     * Runs a semantic search against the locally-indexed embeddings and
+     * returns matching chunks ranked by similarity.
+     *
+     * The `query` is either plain text (which gets embedded internally) or
+     * `{ noteId }`, which reuses the note's already-indexed chunks as the
+     * query — useful for "find related notes" / tag suggestion / semantic
+     * graph use cases without spending another embedding pass.
+     *
+     * The `scope` restricts the search: `'all'` (default), `'note'`,
+     * `'folder'` (by folder id), or `'tag'` (by tag id).
+     * Trashed and conflict notes are excluded from results.
+     *
+     * The `relevance` preset controls how strict the match is:
+     * `'strict' | 'normal' | 'loose'`. Joplin owns the mapping from preset
+     * to model-specific (k, minScore) — plugins write against the preset
+     * and stay compatible when the bundled model changes.
+     *
+     * Throws when AI features are disabled or no embedding provider is
+     * active (e.g. ONNX failed to load on this platform).
+     *
+     * @example
+     * ```typescript
+     * const results = await joplin.ai.search({
+     *     query: { text: 'pizza dough hydration' },
+     *     relevance: 'normal',
+     * });
+     * for (const r of results) {
+     *     console.log(r.score, r.noteId, r.chunkText.slice(0, 80));
+     * }
+     * ```
+     */
+    search(options: SearchOptions): Promise<SearchResult[]>;
+}

--- a/api/types.ts
+++ b/api/types.ts
@@ -938,3 +938,93 @@ export enum ContentScriptType {
 	 */
 	CodeMirrorPlugin = 'codeMirrorPlugin',
 }
+
+// =================================================================
+// AI types
+// =================================================================
+
+export type ChatMessageRole = 'system' | 'user' | 'assistant';
+
+/**
+ * A single message in a chat conversation.
+ */
+export interface ChatMessage {
+	role: ChatMessageRole;
+	content: string;
+}
+
+/**
+ * Optional parameters for a chat call. The active model and provider are
+ * controlled by the user in the Joplin settings — plugins cannot pick a model.
+ */
+export interface ChatOptions {
+	/** Sampling temperature, typically between 0 and 1. Provider default if omitted. */
+	temperature?: number;
+	/** Maximum number of tokens to generate. Provider default if omitted. */
+	maxTokens?: number;
+}
+
+/**
+ * Result of a chat call.
+ */
+export interface ChatResult {
+	/** The assistant's text response. */
+	text: string;
+}
+
+/**
+ * Relevance preset for semantic search. Maps internally to model-specific
+ * `(k, minScore)` tuning — the preset is the public contract so plugins keep
+ * working when the bundled embedding model changes.
+ */
+export type SearchRelevance = 'strict' | 'normal' | 'loose';
+
+/**
+ * Where to look for matches.
+ *
+ * - `all`: every indexed note (default).
+ * - `note`: a single note (rarely useful directly — mainly an internal
+ *   building block).
+ * - `folder`: all notes in the given folder (a "notebook" in the UI).
+ * - `tag`: all notes tagged with the given tag.
+ *
+ * Trashed and conflict notes are always excluded.
+ */
+export type SearchScope =
+	| { type: 'all' }
+	| { type: 'note'; noteId: string }
+	| { type: 'folder'; folderId: string }
+	| { type: 'tag'; tagId: string };
+
+/**
+ * What to search for: free text (embedded internally), or an existing note
+ * whose stored chunks are reused as the query — useful for "related notes",
+ * tag suggestions, and graph-style use cases without a second embedding pass.
+ */
+export type SearchQuery =
+	| { text: string }
+	| { noteId: string };
+
+/**
+ * Parameters for {@link JoplinAi.search}.
+ */
+export interface SearchOptions {
+	query: SearchQuery;
+	scope?: SearchScope;
+	relevance?: SearchRelevance;
+}
+
+/**
+ * A single hit from {@link JoplinAi.search}.
+ */
+export interface SearchResult {
+	noteId: string;
+	chunkIndex: number;
+	chunkText: string;
+	/**
+	 * Cosine similarity in `[0, 1]`. Higher means more similar. Plugins should
+	 * use this for ranking but not as an absolute threshold — that's what the
+	 * `relevance` preset is for.
+	 */
+	score: number;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-jarvis",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "scripts": {
     "dist": "webpack --env joplinPluginConfig=buildMain && webpack --env joplinPluginConfig=buildExtraScripts && webpack --env joplinPluginConfig=createArchive",
     "prepare": "npm run dist",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 	"id": "joplin.plugin.alondmnt.jarvis",
 	"app_min_version": "3.3",
 	"platforms": ["desktop", "mobile"],
-	"version": "0.13.3",
+	"version": "0.13.4",
 	"name": "Jarvis",
 	"description": "Joplin AI assistant running a very intelligent system (GPT, Claude, Gemini, Ollama, Hugging Face, ...), including: related notes (semantic search), chat with LLMs and your notes, prompt templates, auto-tags and more.",
 	"author": "Alon Diament",

--- a/src/models/joplinAI.ts
+++ b/src/models/joplinAI.ts
@@ -1,0 +1,96 @@
+import joplin from 'api';
+import type { ChatMessage, ChatMessageRole, ChatOptions } from 'api/types';
+import { ModelError, truncateErrorForDialog } from '../utils';
+
+// Minimum Joplin version that ships the joplin.ai plugin API (desktop beta).
+const MIN_JOPLIN_MAJOR = 3;
+const MIN_JOPLIN_MINOR = 7;
+
+/** Compares a dotted version string against a major.minor floor. */
+function isVersionAtLeast(version: string, major: number, minor: number): boolean {
+  const parts = String(version ?? '').split('.');
+  const vMajor = parseInt(parts[0], 10);
+  const vMinor = parseInt(parts[1] ?? '0', 10);
+  if (!Number.isFinite(vMajor) || !Number.isFinite(vMinor)) { return false; }
+  if (vMajor !== major) { return vMajor > major; }
+  return vMinor >= minor;
+}
+
+/**
+ * Returns true when the running Joplin exposes the AI plugin API.
+ *
+ * We cannot feature-detect `joplin.ai` directly: the plugin sandbox wraps the
+ * `joplin` global in a Proxy that fabricates a truthy value for *any* property
+ * access, so `joplin.ai` and even `typeof joplin.ai.chat === 'function'` are
+ * true regardless of support, failing only (across the IPC boundary) when
+ * actually called. Instead we gate on the app version and platform via
+ * `joplin.versionInfo()`, which returns real host data. The API is a
+ * desktop-only beta introduced in Joplin 3.7. Any failure fails closed.
+ */
+export async function isAvailable(): Promise<boolean> {
+  try {
+    const info = await joplin.versionInfo();
+    if (!info || info.platform !== 'desktop') { return false; }
+    return isVersionAtLeast(info.version, MIN_JOPLIN_MAJOR, MIN_JOPLIN_MINOR);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Sends a chat conversation to the model configured in Joplin's own settings
+ * (Settings → AI) and returns the assistant's text. Jarvis does not own the
+ * provider or API key here — Joplin does — so the failure modes are mostly
+ * configuration issues (AI disabled, remote access not allowed, missing key)
+ * that the user resolves in Joplin, not in Jarvis. On error we surface a
+ * dialog pointing there, then retry on OK or throw a ModelError on cancel
+ * (mirroring the OpenAI/Hugging Face paths).
+ *
+ * @param prompt chat entries with roles already normalised to
+ *   system/user/assistant by the caller
+ * @param temperature sampling temperature on Joplin's 0-1 scale, or
+ *   null/undefined to take the provider default
+ */
+export async function query_chat(
+    prompt: Array<{role: string; content: string;}>,
+    temperature: number): Promise<string> {
+
+  const messages: ChatMessage[] = prompt.map((message) => ({
+    role: message.role as ChatMessageRole,
+    content: message.content,
+  }));
+
+  const options: ChatOptions = {};
+  if (temperature !== null && temperature !== undefined) {
+    options.temperature = temperature;
+  }
+
+  let error_message: string | null = null;
+  try {
+    const result = await joplin.ai.chat(messages, options);
+    if (result && typeof result.text === 'string') {
+      return result.text;
+    }
+    error_message = 'Joplin AI returned an empty response';
+
+  } catch (error) {
+    error_message = error instanceof Error ? error.message : String(error);
+  }
+
+  // display error message (truncated for dialog, full message logged)
+  console.error(`Joplin AI chat error: ${error_message}`);
+  const errorHandler = await joplin.views.dialogs.showMessageBox(
+    `Error from Joplin AI: ${truncateErrorForDialog(error_message)}\n\n` +
+    `Check that AI is enabled and a provider is configured in ` +
+    `Joplin → Settings → AI (and that remote access is allowed for cloud ` +
+    `providers). Press OK to retry.`
+  );
+
+  // cancel button
+  if (errorHandler === 1) {
+    throw new ModelError(`Joplin AI chat failed: ${error_message}`);
+  }
+
+  // retry
+  return await query_chat(prompt, temperature);
+}

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -1679,8 +1679,9 @@ export class JoplinAIGeneration extends TextGenerationModel {
       settings.chat_timeout);
     this.base_chat = [{role: 'system', content: settings.chat_system_message}];
 
-    // Joplin's ChatOptions.temperature is on a 0-1 scale; Jarvis exposes 0-20.
-    this.temperature = settings.temperature / 20;
+    // Joplin's ChatOptions.temperature is on a 0-1 scale; settings.temperature
+    // is already the 0-2 value (raw 0-20 slider divided by 10 at load).
+    this.temperature = settings.temperature / 2;
 
     // rate limiting
     this.requests_per_second = 10;
@@ -1705,6 +1706,14 @@ export class JoplinAIGeneration extends TextGenerationModel {
 
   async _chat(prompt: ChatEntry[]): Promise<string> {
     return joplinAI.query_chat(prompt, this.temperature);
+  }
+
+  async _complete(prompt: string): Promise<string> {
+    // Joplin AI is always a chat model, so route completions (annotate, ask,
+    // autocomplete, research, query decomposition) through the chat path,
+    // mirroring OpenAIGeneration. Without this the base _complete throws
+    // 'Not implemented' for every non-chat command.
+    return this._chat([...this.base_chat, {role: 'user', content: prompt}]);
   }
 }
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -95,6 +95,7 @@ import { consume_rate_limit, timeout_with_retry, escape_regex, replace_last, Mod
 import * as openai from './openai';
 import * as google from './google';
 import * as ollama from './ollama';
+import * as joplinAI from './joplinAI';
 import { BlockEmbedding } from '../notes/embeddings';  // maybe move definition to this file
 import { clear_deleted_notes, connect_to_db, get_all_embeddings, init_db } from '../notes/db';
 
@@ -310,6 +311,9 @@ export async function load_generation_model(settings: JarvisSettings): Promise<T
 
   } else if (settings.model.startsWith('gemini')) {
     model = new GeminiGeneration(settings);
+
+  } else if (settings.model === 'joplin-ai') {
+    model = new JoplinAIGeneration(settings);
 
   } else {
     console.error(`Unknown model: ${settings.model}`);
@@ -1660,6 +1664,47 @@ export class GeminiGeneration extends TextGenerationModel {
   async _complete(prompt: string): Promise<string> {
     return google.query_completion(
       this.model, this.id, prompt, this.temperature, this.top_p);
+  }
+}
+
+export class JoplinAIGeneration extends TextGenerationModel {
+  constructor(settings: JarvisSettings) {
+    super('Joplin AI',
+      settings.max_tokens,
+      'chat',
+      settings.memory_tokens,
+      settings.notes_context_tokens,
+      settings.chat_suffix,
+      settings.chat_prefix,
+      settings.chat_timeout);
+    this.base_chat = [{role: 'system', content: settings.chat_system_message}];
+
+    // Joplin's ChatOptions.temperature is on a 0-1 scale; Jarvis exposes 0-20.
+    this.temperature = settings.temperature / 20;
+
+    // rate limiting
+    this.requests_per_second = 10;
+    this.last_request_time = 0;
+  }
+
+  async _load_model() {
+    // The provider and API key live in Joplin's own settings, so there is
+    // nothing to load or validate here beyond the API being present. Config
+    // errors (AI disabled, remote not allowed, missing key) only surface on
+    // the first chat() call and are handled in joplinAI.query_chat.
+    if (!(await joplinAI.isAvailable())) {
+      joplin.views.dialogs.showMessageBox(
+        'Joplin AI is not available. It requires Joplin 3.7 or newer (desktop) ' +
+        'with AI enabled in Settings → AI. See the Jarvis guide for details.');
+      this.model = null;
+      return;
+    }
+    this.model = 'Joplin AI';  // truthy sentinel; the active model is chosen in Joplin
+    console.log(this.id);
+  }
+
+  async _chat(prompt: ChatEntry[]): Promise<string> {
+    return joplinAI.query_chat(prompt, this.temperature);
   }
 }
 

--- a/src/ux/settings.ts
+++ b/src/ux/settings.ts
@@ -487,6 +487,7 @@ export async function register_settings() {
       description: 'The model to ask / chat / research with Jarvis. All predefined models are ONLINE, but custom OFFLINE models are supported. Default: gpt-5-mini',
       options: {
         'none': 'None (disable generation features)',
+        'joplin-ai': 'Joplin AI (built-in, configured in Joplin → Settings → AI)',
         'openai-custom': 'OpenAI-compatible custom model (e.g., Ollama, Claude)',
         'gpt-5-nano':'gpt-5-nano / OpenAI (in:400K, out:128K, cheapest reasoning)',
         'gpt-5-mini':'gpt-5-mini / OpenAI (in:400K, out:128K)',


### PR DESCRIPTION
## What

Adds **Joplin AI** as a chat provider — Jarvis chats through the model configured in Joplin's own **Settings → AI** (Joplin Cloud AI, an OpenAI-compatible endpoint, or Anthropic) via the beta `joplin.ai.chat` API, so no API key is needed in Jarvis. It's the **second option** in the `Chat: Model` dropdown, non-default.

Scope is **chat only**. Joplin AI's embedding side (`getEmbeddings`/`search`) has no embed-arbitrary-text-to-vector method, so it can't back Jarvis's `TextEmbeddingModel`; using `search()` as a retrieval backend for Related Notes / chat-with-notes is a separate, larger feature and is deferred.

## How it works

- `JoplinAIGeneration extends TextGenerationModel` maps our `{role, content}[]` straight onto `joplin.ai.chat` (non-streaming, returns `.text`), mirroring the OpenAI/Anthropic path. Temperature is passed through, mapping Jarvis's 0–20 scale to Joplin's 0–1; `maxTokens` is omitted (provider default) for v1.
- **Availability is gated on `joplin.versionInfo()` (desktop, Joplin 3.7+)**, not on probing `joplin.ai`. The plugin sandbox proxies every property access to a truthy value, so the namespace can't be feature-detected — it only errors when called across the IPC boundary. The version gate fails closed (try/catch).
- Graceful degradation:
  - old Joplin / mobile → clean "requires Joplin 3.7+ (desktop)" popup at load; model stays off, nothing breaks.
  - 3.7+ but AI disabled / remote not allowed / missing key → loads fine; the error surfaces on the first chat with a message pointing at **Joplin → Settings → AI**.
- **Blast radius is minimal:** nothing outside `models.ts` branches on the model string, and every downstream feature-gate keys off `model.model === null`, so the null-sentinel handles the unavailable case with no new branching. No new settings keys, no API-key field (Joplin owns the key). `app_min_version` stays at 3.3.

## Vendored types

The vendored `api/` types predate `joplin.ai`, so the beta AI plugin API surface (chat + search) is mirrored in from the upstream `generator-joplin` template (`api/JoplinAi.d.ts`, plus the getter in `api/Joplin.d.ts` and the AI types in `api/types.ts`), giving proper typing instead of a cast.

## Testing

- `npm run dist` compiles clean (typecheck + both bundles).
- Manual smoke on Joplin 3.7.x desktop: chat round-trips through the configured provider; disabling AI in Joplin surfaces the expected "enable AI in Settings → AI" popup.

## Commits

- `chore:` vendor Joplin AI plugin API types
- `feat:` add Joplin AI as a chat provider
- `docs:` document Joplin AI chat provider in GUIDE
- `version:` v0.13.4
- `docs:` update CHANGELOG for v0.13.4
