### PR TITLE
Fix sidebar Note mode context for local models

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -78,10 +78,24 @@ export async function chat_with_notes_panel(
   return `${completion}\n\n${result.note_links}`.trim();
 }
 
-/** Panel chat scoped to the currently open note. The note body is prepended to
- *  the panel history and parsed as a prior conversation turn (via _parse_chat's
- *  first_role heuristic), mirroring `chat_with_jarvis` invoked at the end of a
- *  note. Each reply is tagged with a clickable link to the source note. */
+/** Panel chat scoped to the currently open note. The conversation is placed
+ *  first and unfenced so _parse_chat reads it as real turns (it opens with a
+ *  `**User:**` marker, so the note can't be misread as a prior assistant turn),
+ *  then the note body is appended as fenced `Current Joplin note` context that
+ *  lands on the final user turn. This mirrors the collection-mode shape in
+ *  run_notes_chat_pipeline, which local instruction-following models (e.g.
+ *  Ollama llama3.2:3b) reliably treat as document context rather than as prior
+ *  assistant history. Each reply is tagged with a clickable link to the note.
+ *
+ *  The note and the conversation are each bounded by their own token budget
+ *  (context_tokens vs memory_tokens) so they don't compete for space, and the
+ *  `===` fences are assembled after truncation so trimming can never drop a
+ *  fence marker.
+ *
+ *  Known limitation: a note body that contains a bare `===` line (a setext H1
+ *  underline or a manual divider) flips fence parity mid-note. This is usually
+ *  benign; it only mis-parses the note when a `**User:**`/`**Jarvis:**` marker
+ *  appears in the re-exposed region below it. Shared with run_notes_chat_pipeline. */
 export async function chat_with_note_panel(
   history: PanelChatMessage[],
   model_gen: TextGenerationModel,
@@ -93,13 +107,36 @@ export async function chat_with_note_panel(
   }
   try {
     const title = note.title || 'Untitled';
-    const note_body = stripJarvisBlocks(note.body ?? '');
-    const chat_block = format_as_note_chat(history, settings);
-    const composed = `${note_body}\n${chat_block}`;
-    const truncated = split_by_tokens(
-      [composed], model_gen, model_gen.memory_tokens, 'last',
+    // bound the note by its own context budget (keeping the top when trimming)
+    // so it never competes with the conversation for memory_tokens
+    const note_body = split_by_tokens(
+      [stripJarvisBlocks(note.body ?? '')], model_gen, model_gen.context_tokens, 'first',
     )[0].join(' ');
-    const raw = (await model_gen.chat(truncated)) || '';
+    // conversation first and unfenced: it opens with a `**User:**` marker, so
+    // _parse_chat reads it as real turns rather than triggering the first_role
+    // heuristic that misattributed the note as an assistant turn
+    const chat_block = split_by_tokens(
+      [format_as_note_chat(history, settings)], model_gen, model_gen.memory_tokens, 'last',
+    )[0].join(' ');
+    // assemble the `===` fences after truncation so a trim can't drop a fence;
+    // the fenced note lands on the final user turn as explicit document context
+    const composed = `${chat_block}
+===
+End of conversation
+===
+
+Current Joplin note
+===
+Title: ${title}
+
+${note_body}
+===
+
+Instructions
+===
+Use the Current Joplin note above as context. If the user asks you to summarise or answer questions about this note, use that note directly. Do not ask the user for a URL or to paste the note text.
+===`;
+    const raw = (await model_gen.chat(composed)) || '';
     const completion = raw
       .replace(model_gen.model_prefix, '')
       .replace(model_gen.user_prefix, '')


### PR DESCRIPTION
Restructures `chat_with_note_panel()` so the current note reaches the model as explicit document context instead of prior assistant history.

**Root cause** (diagnosed by @TwentySeven28 in #78): the note body was prepended before the panel history and the whole string truncated by `memory_tokens`, so `_parse_chat`'s `first_role` heuristic read the note as a prior assistant turn. Local instruction-following models (Ollama `llama3.2:3b`) then replied that no note context was provided.

**Fix:** mirror the collection-mode shape in `run_notes_chat_pipeline` — conversation first and unfenced (parses as real turns, opens with `**User:**`), note appended as a fenced `Current Joplin note` section that lands on the final user turn. The note and the conversation each get their own token budget (`context_tokens` vs `memory_tokens`) so they don't compete, and the `===` fences are assembled *after* truncation so a trim can never drop a fence marker.

**Supersedes #79**, which fixed the same bug but truncated the already-fenced string, so a long note lost its opening fence and parity flipped.

**Verification:** no Ollama in the dev loop, so tested at the parse level against `_parse_chat` — old shape → note on an assistant turn; new shape → note on a user turn; oversized note keeps fences balanced; multi-turn preserved; a literal `**User:**` line inside the note stays as content. Not run end-to-end against a local model; @TwentySeven28 or I can confirm that separately.

**Known limitation** (pre-existing, shared with `run_notes_chat_pipeline`, tracked separately): a bare `===` line inside a note body flips fence parity mid-note; benign unless a role marker appears in the re-exposed region.

Fixes #78.

Co-authored-by: TwentySeven28 <72940366+TwentySeven28@users.noreply.github.com>
