### PR TITLE
Guard split_by_tokens against non-positive budgets (no more hang)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,11 +59,22 @@ export function split_by_tokens(
   split_by: string = ' ',  // can be null to split by characters
 ): Array<Array<string>> {
 
+  // A budget below one token can never hold any content, and preprocess would
+  // recurse forever trying to shrink a part to fit it. Return a single empty
+  // selection so callers' `[0].join(...)` yields '' instead of hanging. This
+  // happens when a caller derives the budget as `max_tokens - prompt_tokens`
+  // and the prompt already exceeds the context.
+  if (max_tokens < 1) { return [[]]; }
+
   // preprocess parts to ensure each part is smaller than max_tokens
   function preprocess(part: string): Array<string> {
     const token_count = model.count_tokens(part);
 
     if (token_count <= max_tokens) { return [part]; }
+
+    // A single character can't be split further; accept it even if its
+    // estimated token count still exceeds the budget, so recursion terminates.
+    if (part.length <= 1) { return [part]; }
 
     // split the part in half
     let part_arr: any = part;


### PR DESCRIPTION
`split_by_tokens`'s `preprocess()` assumes a part can always be split until it fits `max_tokens`. When the budget is below one token — e.g. a caller derives it as `max_tokens - prompt_tokens` and the prompt already exceeds the context (annotate title/summary) — no part can ever fit, and `preprocess` recurses forever on a one-character slice, hanging the plugin.

**Fix:** two guards make the function total —

- return a single empty selection when `max_tokens < 1` (callers' `[0].join()` yields `''`);
- stop splitting a one-character part even if it still exceeds the budget.

All callers pass `[0].join(...)`, which is safe on `[[]]`; normal positive budgets are unchanged.

**Verification:** a termination harness (verbatim copy of `split_by_tokens` + `count_tokens`) confirms negative / zero / fractional budgets now return `''` instead of hanging, and normal budgets truncate as before — 9/9 assertions pass, typecheck clean.

Found while reviewing #84. The likeliest real-world trigger is a very long custom annotation prompt combined with a small `max_tokens`.
