### PR TITLE
Extract completion prefix stripping into clean_completion

### DIFF
--- a/src/chatPanel.ts
+++ b/src/chatPanel.ts
@@ -198,11 +198,7 @@ export async function initialize_chat_panel(get_context: () => ChatPanelContext)
         if (!panelCache.createdAt) panelCache.createdAt = local_timestamp(new Date());
         const full_prompt = format_as_note_chat(history, runtime.settings);
 
-        const raw = await runtime.model_gen.chat(full_prompt);
-        const text = (raw || '')
-          .replace(runtime.model_gen.model_prefix, '')
-          .replace(runtime.model_gen.user_prefix, '')
-          .trim();
+        const text = runtime.model_gen.clean_completion(await runtime.model_gen.chat(full_prompt));
         const html = md.render(text);
         panelCache.history.push({ role: 'assistant', content: text, html });
         return { type: 'response', text, html };

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -70,10 +70,7 @@ export async function chat_with_notes_panel(
     return 'No notes found. Perhaps try to rephrase your question, or start a new chat note for fresh context.';
   }
 
-  const completion = result.completion
-    .replace(model_gen.model_prefix, '')
-    .replace(model_gen.user_prefix, '')
-    .trim();
+  const completion = model_gen.clean_completion(result.completion);
 
   return `${completion}\n\n${result.note_links}`.trim();
 }
@@ -136,11 +133,7 @@ Instructions
 ===
 Use the Current Joplin note above as context. If the user asks you to summarise or answer questions about this note, use that note directly. Do not ask the user for a URL or to paste the note text.
 ===`;
-    const raw = (await model_gen.chat(composed)) || '';
-    const completion = raw
-      .replace(model_gen.model_prefix, '')
-      .replace(model_gen.user_prefix, '')
-      .trim();
+    const completion = model_gen.clean_completion(await model_gen.chat(composed));
     return `${completion}\n\n[${title}](:/${note.id})`;
   } finally {
     clearObjectReferences(note);

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -1187,6 +1187,15 @@ export class TextGenerationModel {
     return estimateTokens(text);
   }
 
+  // strip the role prefixes this model wraps around a reply (chat() returns
+  // model_prefix + text + user_prefix), leaving the bare completion text
+  clean_completion(text: string): string {
+    return (text || '')
+      .replace(this.model_prefix, '')
+      .replace(this.user_prefix, '')
+      .trim();
+  }
+
   // rate limiter
   async limit_rate() {
     const request_promise = new Promise((resolve, reject) => {


### PR DESCRIPTION
The idiom that strips a model's role prefixes from a reply (`.replace(model_prefix, '').replace(user_prefix, '').trim()`) was duplicated across `chatPanel.ts` and two functions in `chat.ts`. Since the model owns its prefixes, this moves it to a `TextGenerationModel.clean_completion` method and calls it at the three sites.

Pure refactor — byte-identical output, with the `|| ''` guard folded into the method. Typecheck clean.

Closes #83.
